### PR TITLE
Add WordPress Blueprints

### DIFF
--- a/.wporg/blueprints/blueprint.json
+++ b/.wporg/blueprints/blueprint.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Feature Flipper",
+		"description": "Easily switch some features in WordPress, on and off",
+		"author": "tfirdaus"
+	},
+	"preferredVersions": {
+		"php": "7.4",
+		"wp": "latest"
+	},
+    "landingPage": "/wp-admin/options-general.php?page=syntatis-feature-flipper",
+	"steps": [
+		{
+			"step": "login"
+		}
+	]
+}

--- a/.wporg/blueprints/blueprint.json
+++ b/.wporg/blueprints/blueprint.json
@@ -1,18 +1,13 @@
 {
-	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"meta": {
-		"title": "Feature Flipper",
-		"description": "Easily switch some features in WordPress, on and off",
-		"author": "tfirdaus"
-	},
-	"preferredVersions": {
-		"php": "7.4",
-		"wp": "latest"
-	},
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "preferredVersions": {
+        "php": "7.4",
+        "wp": "latest"
+    },
     "landingPage": "/wp-admin/options-general.php?page=syntatis-feature-flipper",
-	"steps": [
-		{
-			"step": "login"
-		}
-	]
+    "steps": [
+        {
+            "step": "login"
+        }
+    ]
 }


### PR DESCRIPTION
This Pull Request adds the initial configuration to enable [WordPress Blueprints](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) to allow user to preview the plugin right from WordPress.org.