### PR TITLE
Optimize jQuery migrate handling

### DIFF
--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Syntatis\FeatureFlipper\Modules;
 
+use _WP_Dependency;
 use SSFV\Codex\Contracts\Extendable;
 use SSFV\Codex\Contracts\Hookable;
 use SSFV\Codex\Foundation\Hooks\Hook;
@@ -46,11 +47,10 @@ class Site implements Hookable, Extendable
 			$hook->addAction('wp_default_scripts', static function (WP_Scripts $scripts): void {
 				$jquery = $scripts->query('jquery', 'registered');
 
-				if ($jquery === false) {
+				if (! $jquery instanceof _WP_Dependency) {
 					return;
 				}
 
-				/** @phpstan-var \_WP_Dependency $jquery */
 				$jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
 			});
 		}

--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -44,17 +44,13 @@ class Site implements Hookable, Extendable
 
 		if (! (bool) Option::get('jquery_migrate')) {
 			$hook->addAction('wp_default_scripts', static function (WP_Scripts $scripts): void {
-				if (! isset($scripts->registered['jquery'])) {
+				$jquery = $scripts->query('jquery');
+
+				if ($jquery === false) {
 					return;
 				}
 
-				$script = $scripts->registered['jquery'];
-
-				if ($script->deps === []) {
-					return;
-				}
-
-				$script->deps = array_diff($script->deps, ['jquery-migrate']);
+				$jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
 			});
 		}
 

--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -44,12 +44,13 @@ class Site implements Hookable, Extendable
 
 		if (! (bool) Option::get('jquery_migrate')) {
 			$hook->addAction('wp_default_scripts', static function (WP_Scripts $scripts): void {
-				$jquery = $scripts->query('jquery');
+				$jquery = $scripts->query('jquery', 'registered');
 
 				if ($jquery === false) {
 					return;
 				}
 
+				/** @var \_WP_Dependency $jquery */
 				$jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
 			});
 		}

--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -50,7 +50,7 @@ class Site implements Hookable, Extendable
 					return;
 				}
 
-				/** @var \_WP_Dependency $jquery */
+				/** @phpstan-var \_WP_Dependency $jquery */
 				$jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
 			});
 		}


### PR DESCRIPTION
- use `WP_Dependencies::query` only once
- remove empty deps checking

@tfirdaus