### PR TITLE
Introduce Option::isOn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,21 +35,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "7.4"
-          tools: composer:v2
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Setup Composer cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-7.4-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: php-7.4-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v3
 
       - name: Run PHPCS
         run: composer run phpcs
@@ -87,21 +75,11 @@ jobs:
       - name: Get Docker version
         run: docker -v
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Install NodeJS dependencies
+        run: npm ci
 
-      - name: Setup Composer cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-7.4-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: php-7.4-composer-
-
-      - name: Install dependencies
-        run: |
-          npm install
-          composer install --prefer-dist --no-interaction --no-progress --optimize-autoloader
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v3
 
       - name: Start wp-env
         run: |
@@ -110,7 +88,7 @@ jobs:
           npm run wp-env:tests-wordpress php -- -v
 
       - name: Run PHPUnit
-        run: composer phpunit
+        run: composer run phpunit
 
   typos:
     runs-on: ubuntu-latest

--- a/app/Features/AdminBar.php
+++ b/app/Features/AdminBar.php
@@ -50,11 +50,11 @@ class AdminBar implements Hookable
 		$hook->addAction('admin_enqueue_scripts', [$this, 'enqueueScripts']);
 		$hook->addAction('wp_enqueue_scripts', [$this, 'enqueueScripts']);
 
-		if (! (bool) Option::get('admin_bar_howdy')) {
+		if (! Option::isOn('admin_bar_howdy')) {
 			$hook->addAction('admin_bar_menu', [$this, 'addMyAccountNode'], PHP_INT_MAX);
 		}
 
-		if ((bool) Option::get('admin_bar_env_type')) {
+		if (Option::isOn('admin_bar_env_type')) {
 			$hook->addAction('admin_bar_menu', [$this, 'addEnvironmentTypeNode']);
 		}
 
@@ -214,7 +214,7 @@ class AdminBar implements Hookable
 
 	public function showAdminBar(bool $value): bool
 	{
-		return is_user_logged_in() ? (bool) Option::get('admin_bar') : $value;
+		return is_user_logged_in() ? Option::isOn('admin_bar') : $value;
 	}
 
 	/** @return array<string> */
@@ -222,7 +222,7 @@ class AdminBar implements Hookable
 	{
 		$excludes = self::DEFAULT_EXCLUDED_MENU;
 
-		if (! (bool) Option::get('comments')) {
+		if (! Option::isOn('comments')) {
 			$excludes = [
 				...$excludes,
 				'comments',

--- a/app/Features/Attachment.php
+++ b/app/Features/Attachment.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Syntatis\FeatureFlipper\Features;
+
+use SSFV\Codex\Contracts\Hookable;
+use SSFV\Codex\Foundation\Hooks\Hook;
+use SSFV\Symfony\Component\Uid\Uuid;
+use Syntatis\FeatureFlipper\Concerns\WithHookName;
+use Syntatis\FeatureFlipper\Helpers\Option;
+use WP_Query;
+
+use function is_string;
+
+class Attachment implements Hookable
+{
+	use WithHookName;
+
+	public function hook(Hook $hook): void
+	{
+		$hook->addFilter(self::defaultOptionHook('attachment_page'), static function () {
+			/**
+			 * In WordPress 6.4, A new option, `wp_attachment_pages_enabled` is introduced
+			 * to control the attachment page behavior.
+			 *
+			 * - For new sites, the option will be set to `0` by default, and the attachment
+			 * page will be disabled.
+			 * - For existing sites, the option will be set to `1` after the upgrade and
+			 * the attachment page will
+			 * remain enabled.
+			 *
+			 * By default, this plugin will follow this default behavior.
+			 *
+			 * @see https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/
+			 */
+			$enabled = get_option('wp_attachment_pages_enabled', null);
+
+			return $enabled === '1' || $enabled === null;
+		});
+		$hook->addAction(
+			self::addOptionHook('attachment_page'),
+			static function ($option, $value): void {
+				update_option('wp_attachment_pages_enabled', (bool) $value ? '1' : '0');
+			},
+			10,
+			2,
+		);
+		$hook->addAction(
+			self::updateOptionHook('attachment_page'),
+			static function ($oldValue, $newValue): void {
+				update_option('wp_attachment_pages_enabled', (bool) $newValue ? '1' : '0');
+			},
+			10,
+			2,
+		);
+
+		// 1. Attachment Page.
+		if (! (bool) Option::get('attachment_page')) {
+			$hook->addAction('template_redirect', function (): void {
+				if (! is_attachment()) {
+					return;
+				}
+
+				$this->toNotFound();
+			});
+
+			$hook->addFilter(
+				'redirect_canonical',
+				function (string $url) {
+					if (! is_attachment()) {
+						return $url;
+					}
+
+					$this->toNotFound();
+				},
+			);
+
+			/**
+			 * Replace the link to "View Attachment Page" with the actual attachment URL.
+			 */
+			$hook->addFilter('attachment_link', static function (string $url, int $id): string {
+				$attachmentUrl = wp_get_attachment_url($id);
+
+				if (is_string($attachmentUrl)) {
+					return $attachmentUrl;
+				}
+
+				return $url;
+			}, 99, 2);
+		}
+
+		if ((bool) Option::get('attachment_slug')) {
+			return;
+		}
+
+		$hook->addFilter(
+			'wp_unique_post_slug',
+			static function (string $slug, string $id, string $status, string $type): string {
+				if ($type !== 'attachment' || Uuid::isValid($slug)) {
+					return $slug;
+				}
+
+				return (string) Uuid::v5(Uuid::fromString(Uuid::NAMESPACE_URL), $slug);
+			},
+			99,
+			4,
+		);
+	}
+
+	private function toNotFound(): void
+	{
+		/** @var WP_Query|null $wpQuery */
+		$wpQuery = $GLOBALS['wp_query'] ?? null;
+
+		if ($wpQuery === null) {
+			return;
+		}
+
+		$wpQuery->set_404();
+		status_header(404);
+		nocache_headers();
+	}
+}

--- a/app/Features/Attachment.php
+++ b/app/Features/Attachment.php
@@ -56,7 +56,7 @@ class Attachment implements Hookable
 		);
 
 		// 1. Attachment Page.
-		if (! (bool) Option::get('attachment_page')) {
+		if (! Option::isOn('attachment_page')) {
 			$hook->addAction('template_redirect', function (): void {
 				if (! is_attachment()) {
 					return;
@@ -90,7 +90,7 @@ class Attachment implements Hookable
 			}, 99, 2);
 		}
 
-		if ((bool) Option::get('attachment_slug')) {
+		if (Option::isOn('attachment_slug')) {
 			return;
 		}
 

--- a/app/Features/Comments.php
+++ b/app/Features/Comments.php
@@ -21,7 +21,7 @@ class Comments implements Hookable
 {
 	public function hook(Hook $hook): void
 	{
-		if ((bool) Option::get('comments')) {
+		if (Option::isOn('comments')) {
 			return;
 		}
 

--- a/app/Features/DashboardWidgets.php
+++ b/app/Features/DashboardWidgets.php
@@ -64,7 +64,7 @@ class DashboardWidgets implements Hookable
 			return;
 		}
 
-		if (! (bool) Option::get('dashboard_widgets')) {
+		if (! Option::isOn('dashboard_widgets')) {
 			// @phpstan-ignore offsetAccess.nonOffsetAccessible
 			$GLOBALS['wp_meta_boxes']['dashboard'] = []; // phpcs:ignore
 

--- a/app/Features/Embeds.php
+++ b/app/Features/Embeds.php
@@ -23,7 +23,7 @@ class Embeds implements Hookable
 {
 	public function hook(Hook $hook): void
 	{
-		if ((bool) Option::get('embed')) {
+		if (Option::isOn('embed')) {
 			return;
 		}
 

--- a/app/Features/Feeds.php
+++ b/app/Features/Feeds.php
@@ -14,7 +14,7 @@ class Feeds implements Hookable
 {
 	public function hook(Hook $hook): void
 	{
-		if ((bool) Option::get('feeds')) {
+		if (Option::isOn('feeds')) {
 			return;
 		}
 

--- a/app/Features/Gutenberg.php
+++ b/app/Features/Gutenberg.php
@@ -47,7 +47,7 @@ class Gutenberg implements Hookable
 	public function filterUseBlockEditorForPost(bool $value, $post): bool
 	{
 		// If the Gutenberg feature is disabled, force the classic editor.
-		if (! (bool) Option::get('gutenberg')) {
+		if (! Option::isOn('gutenberg')) {
 			return false;
 		}
 

--- a/app/Features/Heartbeat.php
+++ b/app/Features/Heartbeat.php
@@ -39,7 +39,7 @@ class Heartbeat implements Hookable, Extendable
 
 	public function deregisterScripts(): void
 	{
-		if ((bool) Option::get('heartbeat')) {
+		if (Option::isOn('heartbeat')) {
 			return;
 		}
 

--- a/app/Features/Heartbeat/ManageAdmin.php
+++ b/app/Features/Heartbeat/ManageAdmin.php
@@ -32,11 +32,11 @@ class ManageAdmin implements Hookable
 		 */
 		$hook->addFilter(
 			self::optionHook('heartbeat_admin'),
-			static fn ($value) => (bool) Option::get('heartbeat') ? $value : false,
+			static fn ($value) => Option::isOn('heartbeat') ? $value : false,
 		);
 		$hook->addFilter(
 			self::defaultOptionHook('heartbeat_admin'),
-			static fn ($value) => (bool) Option::get('heartbeat') ? $value : false,
+			static fn ($value) => Option::isOn('heartbeat') ? $value : false,
 		);
 	}
 
@@ -45,7 +45,7 @@ class ManageAdmin implements Hookable
 	 */
 	public function deregisterScripts(): void
 	{
-		if (! is_admin() || self::isPostEditor() || (bool) Option::get('heartbeat_admin')) {
+		if (! is_admin() || self::isPostEditor() || Option::isOn('heartbeat_admin')) {
 			return;
 		}
 

--- a/app/Features/Heartbeat/ManagePostEditor.php
+++ b/app/Features/Heartbeat/ManagePostEditor.php
@@ -32,11 +32,11 @@ class ManagePostEditor implements Hookable
 		 */
 		$hook->addFilter(
 			self::optionHook('heartbeat_post_editor'),
-			static fn ($value) => (bool) Option::get('heartbeat') ? $value : false,
+			static fn ($value) => Option::isOn('heartbeat') ? $value : false,
 		);
 		$hook->addFilter(
 			self::defaultOptionHook('heartbeat_post_editor'),
-			static fn ($value) => (bool) Option::get('heartbeat') ? $value : false,
+			static fn ($value) => Option::isOn('heartbeat') ? $value : false,
 		);
 	}
 
@@ -45,7 +45,7 @@ class ManagePostEditor implements Hookable
 	 */
 	public function deregisterScripts(): void
 	{
-		if (! self::isPostEditor() || (bool) Option::get('heartbeat_post_editor')) {
+		if (! self::isPostEditor() || Option::isOn('heartbeat_post_editor')) {
 			return;
 		}
 

--- a/app/Features/Updates.php
+++ b/app/Features/Updates.php
@@ -39,12 +39,12 @@ class Updates implements Hookable, Extendable
 			static fn ($value) => Helpers\AutoUpdate::global()->isEnabled((bool) $value),
 		);
 
-		if (! (bool) Option::get('updates')) {
+		if (! Option::isOn('updates')) {
 			$hook->addAction('admin_menu', [$this, 'removeUpdateAdminMenu'], PHP_INT_MAX);
 			$hook->removeAction('init', 'wp_schedule_update_checks');
 		}
 
-		if ((bool) Option::get('auto_updates')) {
+		if (Option::isOn('auto_updates')) {
 			return;
 		}
 

--- a/app/Features/Updates/ManageCore.php
+++ b/app/Features/Updates/ManageCore.php
@@ -27,7 +27,7 @@ class ManageCore implements Hookable
 	{
 		$updatesFn = static fn ($value) => Updates::core()->isEnabled((bool) $value);
 		$autoUpdateFn = static function ($value): bool {
-			if (! (bool) Option::get('update_core')) {
+			if (! Option::isOn('update_core')) {
 				return false;
 			}
 
@@ -39,7 +39,7 @@ class ManageCore implements Hookable
 		$hook->addFilter(self::optionHook('auto_update_core'), $autoUpdateFn);
 		$hook->addFilter(self::optionHook('update_core'), $updatesFn);
 
-		if (! (bool) Option::get('update_core')) {
+		if (! Option::isOn('update_core')) {
 			$hook->addFilter('schedule_event', [$this, 'filterScheduleEvent']);
 			$hook->addFilter('send_core_update_notification_email', '__return_false');
 			$hook->addFilter('site_transient_update_core', [$this, 'filterSiteTransientUpdate']);
@@ -49,7 +49,7 @@ class ManageCore implements Hookable
 			$hook->removeAction('wp_version_check', 'wp_version_check');
 		}
 
-		if ((bool) Option::get('auto_update_core')) {
+		if (Option::isOn('auto_update_core')) {
 			return;
 		}
 

--- a/app/Features/Updates/ManagePlugins.php
+++ b/app/Features/Updates/ManagePlugins.php
@@ -24,7 +24,7 @@ class ManagePlugins implements Hookable
 	{
 		$updatesFn = static fn ($value) => Updates::plugins()->isEnabled((bool) $value);
 		$autoUpdateFn = static function ($value): bool {
-			if (! (bool) Option::get('update_plugins')) {
+			if (! Option::isOn('update_plugins')) {
 				return false;
 			}
 
@@ -36,7 +36,7 @@ class ManagePlugins implements Hookable
 		$hook->addFilter(self::optionHook('auto_update_plugins'), $autoUpdateFn);
 		$hook->addFilter(self::optionHook('update_plugins'), $updatesFn);
 
-		if (! (bool) Option::get('update_plugins')) {
+		if (! Option::isOn('update_plugins')) {
 			$hook->removeAction('admin_init', '_maybe_update_plugins');
 			$hook->removeAction('load-plugins.php', 'wp_plugin_update_rows', 20);
 			$hook->removeAction('load-plugins.php', 'wp_update_plugins');
@@ -46,7 +46,7 @@ class ManagePlugins implements Hookable
 			$hook->addFilter('site_transient_update_plugins', [$this, 'filterSiteTransientUpdate']);
 		}
 
-		if ((bool) Option::get('auto_update_plugins')) {
+		if (Option::isOn('auto_update_plugins')) {
 			return;
 		}
 

--- a/app/Features/Updates/ManageThemes.php
+++ b/app/Features/Updates/ManageThemes.php
@@ -24,7 +24,7 @@ class ManageThemes implements Hookable
 	{
 		$updatesFn = static fn ($value) => Updates::themes()->isEnabled((bool) $value);
 		$autoUpdateFn = static function ($value): bool {
-			if (! (bool) Option::get('update_themes')) {
+			if (! Option::isOn('update_themes')) {
 				return false;
 			}
 
@@ -36,7 +36,7 @@ class ManageThemes implements Hookable
 		$hook->addFilter(self::optionHook('auto_update_themes'), $autoUpdateFn);
 		$hook->addFilter(self::optionHook('update_themes'), $updatesFn);
 
-		if (! (bool) Option::get('update_themes')) {
+		if (! Option::isOn('update_themes')) {
 			$hook->addFilter('site_transient_update_themes', [$this, 'filterSiteTransientUpdate']);
 			$hook->removeAction('admin_init', '_maybe_update_themes');
 			$hook->removeAction('load-themes.php', 'wp_theme_update_rows', 20);
@@ -46,7 +46,7 @@ class ManageThemes implements Hookable
 			$hook->removeAction('wp_update_themes', 'wp_update_themes');
 		}
 
-		if ((bool) Option::get('auto_update_themes')) {
+		if (Option::isOn('auto_update_themes')) {
 			return;
 		}
 

--- a/app/Helpers/AutoUpdate.php
+++ b/app/Helpers/AutoUpdate.php
@@ -45,7 +45,7 @@ class AutoUpdate implements Enable
 	/** @param bool $value Current value of the option passed from the `option_` filter argument. */
 	public function isEnabled(bool $value): bool
 	{
-		if (! (bool) Option::get('updates')) {
+		if (! Option::isOn('updates')) {
 			return false;
 		}
 

--- a/app/Helpers/AutoUpdateComponents.php
+++ b/app/Helpers/AutoUpdateComponents.php
@@ -11,11 +11,11 @@ class AutoUpdateComponents implements Enable
 	/** @param bool $value Current value of the option passed from the `option_` filter argument. */
 	public function isEnabled(bool $value): bool
 	{
-		if (! (bool) Option::get('updates')) {
+		if (! Option::isOn('updates')) {
 			return false;
 		}
 
-		if (! (bool) Option::get('auto_updates')) {
+		if (! Option::isOn('auto_updates')) {
 			return false;
 		}
 

--- a/app/Helpers/Option.php
+++ b/app/Helpers/Option.php
@@ -6,6 +6,8 @@ namespace Syntatis\FeatureFlipper\Helpers;
 
 use SSFV\Codex\Facades\Config;
 
+use function in_array;
+
 class Option
 {
 	/**

--- a/app/Helpers/Option.php
+++ b/app/Helpers/Option.php
@@ -21,6 +21,16 @@ class Option
 	}
 
 	/**
+	 * Check whether a plugin option is enabled.
+	 *
+	 * @phpstan-param non-empty-string $name
+	 */
+	public static function isOn(string $name): bool
+	{
+		return (bool) self::get($name);
+	}
+	
+	/**
 	 * Update the plugin option.
 	 *
 	 * @param string $name  Name of the option to update. Expected to not be SQL-escaped.

--- a/app/Helpers/Option.php
+++ b/app/Helpers/Option.php
@@ -27,9 +27,9 @@ class Option
 	 */
 	public static function isOn(string $name): bool
 	{
-		return (bool) self::get($name);
+		return self::get($name) === '1';
 	}
-	
+
 	/**
 	 * Update the plugin option.
 	 *

--- a/app/Helpers/Option.php
+++ b/app/Helpers/Option.php
@@ -27,7 +27,7 @@ class Option
 	 */
 	public static function isOn(string $name): bool
 	{
-		return self::get($name) === '1';
+		return in_array(self::get($name), [true, '1'], true);
 	}
 
 	/**

--- a/app/Helpers/UpdatesComponents.php
+++ b/app/Helpers/UpdatesComponents.php
@@ -11,7 +11,7 @@ class UpdatesComponents implements Enable
 	/** @param bool $value Current value of the option passed from the `option_` filter argument. */
 	public function isEnabled(bool $value): bool
 	{
-		if (! (bool) Option::get('updates')) {
+		if (! Option::isOn('updates')) {
 			return false;
 		}
 

--- a/app/Modules/Admin.php
+++ b/app/Modules/Admin.php
@@ -16,12 +16,12 @@ class Admin implements Hookable, Extendable
 {
 	public function hook(Hook $hook): void
 	{
-		if (! (bool) Option::get('admin_footer_text')) {
+		if (! Option::isOn('admin_footer_text')) {
 			$hook->addFilter('admin_footer_text', '__return_empty_string', 99);
 			$hook->addFilter('update_footer', '__return_empty_string', 99);
 		}
 
-		if ((bool) Option::get('update_nags')) {
+		if (Option::isOn('update_nags')) {
 			return;
 		}
 

--- a/app/Modules/Advanced.php
+++ b/app/Modules/Advanced.php
@@ -19,7 +19,7 @@ class Advanced implements Hookable, Extendable
 {
 	public function hook(Hook $hook): void
 	{
-		if ((bool) Option::get('cron') || defined('DISABLE_WP_CRON')) {
+		if (Option::isOn('cron') || defined('DISABLE_WP_CRON')) {
 			return;
 		}
 

--- a/app/Modules/General.php
+++ b/app/Modules/General.php
@@ -38,7 +38,7 @@ class General implements Hookable, Extendable
 			PHP_INT_MAX,
 		);
 
-		if (! (bool) Option::get('self_ping')) {
+		if (! Option::isOn('self_ping')) {
 			$hook->addFilter('pre_ping', static function (&$links): void {
 				$links = array_filter($links, static fn ($link) => ! str_starts_with($link, home_url()));
 			}, 99);
@@ -46,7 +46,7 @@ class General implements Hookable, Extendable
 
 		$maxRevisions = Option::get('revisions_max');
 
-		if (! (bool) Option::get('revisions')) {
+		if (! Option::isOn('revisions')) {
 			if (! defined('WP_POST_REVISIONS')) {
 				define('WP_POST_REVISIONS', 0);
 			}

--- a/app/Modules/Media.php
+++ b/app/Modules/Media.php
@@ -20,13 +20,13 @@ class Media implements Hookable, Extendable
 	{
 		$hook->addFilter(
 			'media_library_infinite_scrolling',
-			static fn (): bool => (bool) Option::get('media_infinite_scroll'),
+			static fn (): bool => Option::isOn('media_infinite_scroll'),
 		);
 
 		$hook->addFilter(
 			'jpeg_quality',
 			static function ($quality) {
-				if (! (bool) Option::get('jpeg_compression')) {
+				if (! Option::isOn('jpeg_compression')) {
 					return 100;
 				}
 

--- a/app/Modules/Media.php
+++ b/app/Modules/Media.php
@@ -4,68 +4,20 @@ declare(strict_types=1);
 
 namespace Syntatis\FeatureFlipper\Modules;
 
+use SSFV\Codex\Contracts\Extendable;
 use SSFV\Codex\Contracts\Hookable;
 use SSFV\Codex\Foundation\Hooks\Hook;
-use SSFV\Symfony\Component\Uid\Uuid;
+use SSFV\Psr\Container\ContainerInterface;
+use Syntatis\FeatureFlipper\Concerns\WithHookName;
+use Syntatis\FeatureFlipper\Features\Attachment;
 use Syntatis\FeatureFlipper\Helpers\Option;
-use WP_Query;
 
-use function is_string;
-
-class Media implements Hookable
+class Media implements Hookable, Extendable
 {
+	use WithHookName;
+
 	public function hook(Hook $hook): void
 	{
-		// 1. Attachment Page.
-		if (! (bool) Option::get('attachment_page')) {
-			$hook->addAction('template_redirect', function (): void {
-				if (! is_attachment()) {
-					return;
-				}
-
-				$this->toNotFound();
-			});
-
-			$hook->addFilter(
-				'redirect_canonical',
-				function (string $url) {
-					if (! is_attachment()) {
-						return $url;
-					}
-
-					$this->toNotFound();
-				},
-			);
-
-			/**
-			 * Replace the link to "View Attachment Page" with the actual attachment URL.
-			 */
-			$hook->addFilter('attachment_link', static function (string $url, int $id): string {
-				$attachmentUrl = wp_get_attachment_url($id);
-
-				if (is_string($attachmentUrl)) {
-					return $attachmentUrl;
-				}
-
-				return $url;
-			}, 99, 2);
-		}
-
-		if (! (bool) Option::get('attachment_slug')) {
-			$hook->addFilter(
-				'wp_unique_post_slug',
-				static function (string $slug, string $id, string $status, string $type): string {
-					if ($type !== 'attachment' || Uuid::isValid($slug)) {
-						return $slug;
-					}
-
-					return (string) Uuid::v5(Uuid::fromString(Uuid::NAMESPACE_URL), $slug);
-				},
-				99,
-				4,
-			);
-		}
-
 		$hook->addFilter(
 			'media_library_infinite_scrolling',
 			static fn (): bool => (bool) Option::get('media_infinite_scroll'),
@@ -84,17 +36,9 @@ class Media implements Hookable
 		);
 	}
 
-	public function toNotFound(): void
+	/** @return iterable<object> */
+	public function getInstances(ContainerInterface $container): iterable
 	{
-		/** @var WP_Query|null $wpQuery */
-		$wpQuery = $GLOBALS['wp_query'] ?? null;
-
-		if ($wpQuery === null) {
-			return;
-		}
-
-		$wpQuery->set_404();
-		status_header(404);
-		nocache_headers();
+		yield new Attachment();
 	}
 }

--- a/app/Modules/Security.php
+++ b/app/Modules/Security.php
@@ -22,30 +22,30 @@ class Security implements Hookable, Extendable
 {
 	public function hook(Hook $hook): void
 	{
-		if (! (bool) Option::get('xmlrpc')) {
+		if (! Option::isOn('xmlrpc')) {
 			$hook->addFilter('pings_open', '__return_false');
 			$hook->addFilter('xmlrpc_enabled', '__return_false');
 			$hook->addFilter('xmlrpc_methods', '__return_empty_array');
 			$hook->removeAction('wp_head', 'rsd_link');
 		}
 
-		if (! (bool) Option::get('file_edit') && ! defined('DISALLOW_FILE_EDIT')) {
+		if (! Option::isOn('file_edit') && ! defined('DISALLOW_FILE_EDIT')) {
 			define('DISALLOW_FILE_EDIT', true);
 		}
 
-		if (! (bool) Option::get('application_passwords')) {
+		if (! Option::isOn('application_passwords')) {
 			$hook->addFilter('wp_is_application_passwords_available', '__return_false');
 		}
 
-		if ((bool) Option::get('obfuscate_login_error')) {
+		if (Option::isOn('obfuscate_login_error')) {
 			$hook->addFilter('login_errors', [$this, 'filterLoginErrorMessage']);
 		}
 
-		if ((bool) Option::get('login_block_bots')) {
+		if (Option::isOn('login_block_bots')) {
 			$hook->addAction('init', [$this, 'blockBots'], PHP_INT_MIN);
 		}
 
-		if (! (bool) Option::get('authenticated_rest_api')) {
+		if (! Option::isOn('authenticated_rest_api')) {
 			return;
 		}
 

--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Syntatis\FeatureFlipper\Modules;
 
+use _WP_Dependency;
 use SSFV\Codex\Contracts\Extendable;
 use SSFV\Codex\Contracts\Hookable;
 use SSFV\Codex\Foundation\Hooks\Hook;
@@ -44,17 +45,13 @@ class Site implements Hookable, Extendable
 
 		if (! (bool) Option::get('jquery_migrate')) {
 			$hook->addAction('wp_default_scripts', static function (WP_Scripts $scripts): void {
-				if (! isset($scripts->registered['jquery'])) {
+				$jquery = $scripts->query('jquery', 'registered');
+
+				if (! $jquery instanceof _WP_Dependency) {
 					return;
 				}
 
-				$script = $scripts->registered['jquery'];
-
-				if ($script->deps === []) {
-					return;
-				}
-
-				$script->deps = array_diff($script->deps, ['jquery-migrate']);
+				$jquery->deps = array_diff($jquery->deps, ['jquery-migrate']);
 			});
 		}
 

--- a/app/Modules/Site.php
+++ b/app/Modules/Site.php
@@ -20,7 +20,7 @@ class Site implements Hookable, Extendable
 {
 	public function hook(Hook $hook): void
 	{
-		if (! (bool) Option::get('emojis')) {
+		if (! Option::isOn('emojis')) {
 			/**
 			 * WordPress 6.4 deprecated the use of `print_emoji_styles` function, but it has
 			 * been retained for backward compatibility purposes.
@@ -36,14 +36,14 @@ class Site implements Hookable, Extendable
 			$hook->removeFilter('wp_mail', 'wp_staticize_emoji_for_email');
 		}
 
-		if (! (bool) Option::get('scripts_version')) {
+		if (! Option::isOn('scripts_version')) {
 			$callback = static fn (string $src): string => remove_query_arg('ver', $src);
 
 			$hook->addFilter('script_loader_src', $callback);
 			$hook->addFilter('style_loader_src', $callback);
 		}
 
-		if (! (bool) Option::get('jquery_migrate')) {
+		if (! Option::isOn('jquery_migrate')) {
 			$hook->addAction('wp_default_scripts', static function (WP_Scripts $scripts): void {
 				$jquery = $scripts->query('jquery', 'registered');
 
@@ -55,15 +55,15 @@ class Site implements Hookable, Extendable
 			});
 		}
 
-		if (! (bool) Option::get('rsd_link')) {
+		if (! Option::isOn('rsd_link')) {
 			$hook->removeAction('wp_head', 'rsd_link');
 		}
 
-		if (! (bool) Option::get('generator_tag')) {
+		if (! Option::isOn('generator_tag')) {
 			$hook->removeAction('wp_head', 'wp_generator');
 		}
 
-		if ((bool) Option::get('shortlink')) {
+		if (Option::isOn('shortlink')) {
 			return;
 		}
 

--- a/inc/settings/all.php
+++ b/inc/settings/all.php
@@ -113,7 +113,7 @@ return [
 	 * @see \Syntatis\FeatureFlipper\Modules\Media
 	 */
 	(new Setting('attachment_page', 'boolean'))
-		->withDefault(true),
+		->withDefault(null),
 	(new Setting('attachment_slug', 'boolean'))
 		->withDefault(true),
 	(new Setting('media_infinite_scroll', 'boolean'))

--- a/src/setting-page/tabs/MediaTab.jsx
+++ b/src/setting-page/tabs/MediaTab.jsx
@@ -38,7 +38,13 @@ export const MediaTab = () => {
 							</p>
 							<p>
 								{ __(
-									'When disabled, the attachment pages will be redirected to the homepage.',
+									'When disabled, the attachment page will be redirected to the homepage.',
+									'syntatis-feature-flipper'
+								) }
+							</p>
+							<p>
+								{ __(
+									'On WordPress 6.4 or newer, the attachment page is disabled for new WordPress site installations, by default.',
 									'syntatis-feature-flipper'
 								) }
 							</p>

--- a/tests/phpunit/app/Features/AttachmentTest.php
+++ b/tests/phpunit/app/Features/AttachmentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Syntatis\Tests\Features;
+
+use SSFV\Codex\Foundation\Hooks\Hook;
+use Syntatis\FeatureFlipper\Features\Attachment;
+use Syntatis\FeatureFlipper\Helpers\Option;
+use Syntatis\Tests\WPTestCase;
+
+/**
+ * @group feature-attachment
+ * @group module-media
+ */
+class AttachmentTest extends WPTestCase
+{
+	private Hook $hook;
+	private Attachment $instance;
+
+	// phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- WordPress convention.
+	public function set_up(): void
+	{
+		parent::set_up();
+
+		$this->hook = new Hook();
+		$this->instance = new Attachment();
+		$this->instance->hook($this->hook);
+	}
+
+	/** @testdox should return the default value */
+	public function testOptionDefault(): void
+	{
+		$this->assertEquals('0', get_option('wp_attachment_pages_enabled'));
+		$this->assertFalse(Option::get('attachment_page'));
+	}
+
+	/** @testdox should return the default as true when the option is set to 1 */
+	public function testOptionDefaultEnabled(): void
+	{
+		update_option('wp_attachment_pages_enabled', '1');
+
+		$this->assertEquals('1', get_option('wp_attachment_pages_enabled'));
+		$this->assertTrue(Option::get('attachment_page'));
+	}
+
+	/** @testdox should update the option */
+	public function testOptionUpdated(): void
+	{
+		Option::update('attachment_page', true);
+
+		$this->assertEquals('1', get_option('wp_attachment_pages_enabled'));
+		$this->assertTrue(Option::get('attachment_page'));
+
+		Option::update('attachment_page', false);
+
+		$this->assertEquals('0', get_option('wp_attachment_pages_enabled'));
+		$this->assertFalse(Option::get('attachment_page'));
+	}
+}

--- a/tests/phpunit/app/Features/AttachmentTest.php
+++ b/tests/phpunit/app/Features/AttachmentTest.php
@@ -32,7 +32,7 @@ class AttachmentTest extends WPTestCase
 	public function testOptionDefault(): void
 	{
 		$this->assertEquals('0', get_option('wp_attachment_pages_enabled'));
-		$this->assertFalse(Option::get('attachment_page'));
+		$this->assertFalse(Option::isOn('attachment_page'));
 	}
 
 	/** @testdox should return the default as true when the option is set to 1 */
@@ -41,7 +41,7 @@ class AttachmentTest extends WPTestCase
 		update_option('wp_attachment_pages_enabled', '1');
 
 		$this->assertEquals('1', get_option('wp_attachment_pages_enabled'));
-		$this->assertTrue(Option::get('attachment_page'));
+		$this->assertTrue(Option::isOn('attachment_page'));
 	}
 
 	/** @testdox should update the option */
@@ -50,11 +50,11 @@ class AttachmentTest extends WPTestCase
 		Option::update('attachment_page', true);
 
 		$this->assertEquals('1', get_option('wp_attachment_pages_enabled'));
-		$this->assertTrue(Option::get('attachment_page'));
+		$this->assertTrue(Option::isOn('attachment_page'));
 
 		Option::update('attachment_page', false);
 
 		$this->assertEquals('0', get_option('wp_attachment_pages_enabled'));
-		$this->assertFalse(Option::get('attachment_page'));
+		$this->assertFalse(Option::isOn('attachment_page'));
 	}
 }

--- a/tests/phpunit/app/Features/GutenbergTest.php
+++ b/tests/phpunit/app/Features/GutenbergTest.php
@@ -40,9 +40,9 @@ class GutenbergTest extends WPTestCase
 	/** @testdox should default values */
 	public function testDefaultOptions(): void
 	{
-		$this->assertTrue(Option::get('gutenberg'));
-		$this->assertTrue(Option::get('block_based_widgets'));
-		$this->assertTrue(Option::get('revisions'));
+		$this->assertTrue(Option::isOn('gutenberg'));
+		$this->assertTrue(Option::isOn('block_based_widgets'));
+		$this->assertTrue(Option::isOn('revisions'));
 		$this->assertEquals(['post', 'page'], Option::get('gutenberg_post_types'));
 
 		$callback = static fn ($use, $postType) => $postType === 'page';
@@ -60,7 +60,7 @@ class GutenbergTest extends WPTestCase
 		update_option(Option::name('gutenberg'), false);
 		update_option(Option::name('gutenberg_post_types'), ['post']);
 
-		$this->assertFalse(Option::get('gutenberg'));
+		$this->assertFalse(Option::isOn('gutenberg'));
 		$this->assertEquals(['post'], Option::get('gutenberg_post_types'));
 	}
 

--- a/tests/phpunit/app/Features/Heartbeat/ManageAdminTest.php
+++ b/tests/phpunit/app/Features/Heartbeat/ManageAdminTest.php
@@ -72,7 +72,7 @@ class ManageAdminTest extends WPTestCase
 	/** @testdox should return the default value */
 	public function testOptionDefault(): void
 	{
-		$this->assertTrue(Option::get('heartbeat_admin'));
+		$this->assertTrue(Option::isOn('heartbeat_admin'));
 	}
 
 	/** @testdox should return interval default value */
@@ -95,7 +95,7 @@ class ManageAdminTest extends WPTestCase
 		update_option(Option::name('heartbeat'), false);
 
 		$this->assertFalse(
-			Option::get('heartbeat_admin'),
+			Option::isOn('heartbeat_admin'),
 			'Admin option should be false, since the global option is false.',
 		);
 		$this->assertSame(
@@ -127,7 +127,7 @@ class ManageAdminTest extends WPTestCase
 	{
 		update_option(Option::name('heartbeat_post_editor'), false);
 
-		$this->assertTrue(Option::get('heartbeat_admin'));
+		$this->assertTrue(Option::isOn('heartbeat_admin'));
 		$this->assertSame(60, Option::get('heartbeat_admin_interval'));
 	}
 
@@ -218,7 +218,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert default.
-		$this->assertTrue(Option::get('heartbeat_admin'));
+		$this->assertTrue(Option::isOn('heartbeat_admin'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 
 		// Update.
@@ -228,7 +228,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_admin'));
+		$this->assertFalse(Option::isOn('heartbeat_admin'));
 		$this->assertFalse(wp_script_is('heartbeat', 'registered'));
 	}
 
@@ -248,7 +248,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert default.
-		$this->assertTrue(Option::get('heartbeat_admin'));
+		$this->assertTrue(Option::isOn('heartbeat_admin'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 
 		// Update.
@@ -258,7 +258,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_admin'));
+		$this->assertFalse(Option::isOn('heartbeat_admin'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 	}
 
@@ -278,7 +278,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert default.
-		$this->assertTrue(Option::get('heartbeat_admin'));
+		$this->assertTrue(Option::isOn('heartbeat_admin'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 
 		// Update.
@@ -288,7 +288,7 @@ class ManageAdminTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_admin'));
+		$this->assertFalse(Option::isOn('heartbeat_admin'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 	}
 }

--- a/tests/phpunit/app/Features/Heartbeat/ManagePostEditorTest.php
+++ b/tests/phpunit/app/Features/Heartbeat/ManagePostEditorTest.php
@@ -69,7 +69,7 @@ class ManagePostEditorTest extends WPTestCase
 	/** @testdox should return the default value */
 	public function testOptionDefault(): void
 	{
-		$this->assertTrue(Option::get('heartbeat_post_editor'));
+		$this->assertTrue(Option::isOn('heartbeat_post_editor'));
 	}
 
 	/** @testdox should return the interval default value */
@@ -97,7 +97,7 @@ class ManagePostEditorTest extends WPTestCase
 		update_option(Option::name('heartbeat'), false);
 
 		$this->assertFalse(
-			Option::get('heartbeat_post_editor'),
+			Option::isOn('heartbeat_post_editor'),
 			'Heartbeat post editor option should be false, since the global option is false.',
 		);
 		$this->assertSame(
@@ -125,7 +125,7 @@ class ManagePostEditorTest extends WPTestCase
 	{
 		update_option(Option::name('heartbeat_admin'), false);
 
-		$this->assertTrue(Option::get('heartbeat_post_editor'));
+		$this->assertTrue(Option::isOn('heartbeat_post_editor'));
 		$this->assertSame(15, Option::get('heartbeat_post_editor_interval'));
 	}
 
@@ -222,7 +222,7 @@ class ManagePostEditorTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert default.
-		$this->assertTrue(Option::get('heartbeat_post_editor'));
+		$this->assertTrue(Option::isOn('heartbeat_post_editor'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 
 		// Update.
@@ -232,7 +232,7 @@ class ManagePostEditorTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_post_editor'));
+		$this->assertFalse(Option::isOn('heartbeat_post_editor'));
 		$this->assertFalse(wp_script_is('heartbeat', 'registered'));
 	}
 
@@ -262,7 +262,7 @@ class ManagePostEditorTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_post_editor'));
+		$this->assertFalse(Option::isOn('heartbeat_post_editor'));
 		$this->assertFalse(wp_script_is('heartbeat', 'registered'));
 	}
 
@@ -282,7 +282,7 @@ class ManagePostEditorTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert default.
-		$this->assertTrue(Option::get('heartbeat_post_editor'));
+		$this->assertTrue(Option::isOn('heartbeat_post_editor'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 
 		// Update.
@@ -292,7 +292,7 @@ class ManagePostEditorTest extends WPTestCase
 		$this->instance->deregisterScripts();
 
 		// Assert.
-		$this->assertFalse(Option::get('heartbeat_post_editor'));
+		$this->assertFalse(Option::isOn('heartbeat_post_editor'));
 		$this->assertTrue(wp_script_is('heartbeat', 'registered'));
 	}
 }

--- a/tests/phpunit/app/Features/SiteAccess/PrivateModeTest.php
+++ b/tests/phpunit/app/Features/SiteAccess/PrivateModeTest.php
@@ -49,7 +49,7 @@ class PrivateModeTest extends WPTestCase
 	/** @testdox should carry legacy option */
 	public function testOptionLegacy(): void
 	{
-		$this->assertFalse(Option::get('site_private'));
+		$this->assertFalse(Option::isOn('site_private'));
 		$this->assertSame('public', Option::get('site_access'));
 
 		// Set the legacy option.
@@ -61,12 +61,12 @@ class PrivateModeTest extends WPTestCase
 	/** @testdox should remove the legacy option and return the added value */
 	public function testOptionAdded(): void
 	{
-		$this->assertFalse(Option::get('site_private'));
+		$this->assertFalse(Option::isOn('site_private'));
 		$this->assertTrue(Option::update('site_private', '1'));
 		$this->assertSame('1', Option::get('site_private'));
 
 		$this->assertTrue(Option::add('site_access', 'maintenance'));
-		$this->assertFalse(Option::get('site_private'));
+		$this->assertFalse(Option::isOn('site_private'));
 		$this->assertSame('maintenance', Option::get('site_access'));
 	}
 
@@ -77,13 +77,13 @@ class PrivateModeTest extends WPTestCase
 		$this->assertSame('maintenance', Option::get('site_access'));
 
 		// Update legacy option.
-		$this->assertFalse(Option::get('site_private'));
+		$this->assertFalse(Option::isOn('site_private'));
 		$this->assertTrue(Option::update('site_private', '1'));
 		$this->assertSame('1', Option::get('site_private'));
 
 		// Assert.
 		$this->assertTrue(Option::update('site_access', 'public'));
-		$this->assertFalse(Option::get('site_private'));
+		$this->assertFalse(Option::isOn('site_private'));
 		$this->assertSame('public', Option::get('site_access'));
 	}
 }

--- a/tests/phpunit/app/Features/Updates/ManageCoreTest.php
+++ b/tests/phpunit/app/Features/Updates/ManageCoreTest.php
@@ -112,8 +112,8 @@ class ManageCoreTest extends WPTestCase
 	/** @testdox should return default values */
 	public function testOptionsDefault(): void
 	{
-		$this->assertTrue(Option::get('update_core'));
-		$this->assertTrue(Option::get('auto_update_core'));
+		$this->assertTrue(Option::isOn('update_core'));
+		$this->assertTrue(Option::isOn('auto_update_core'));
 	}
 
 	/** @testdox should return updated values */
@@ -122,8 +122,8 @@ class ManageCoreTest extends WPTestCase
 		update_option(Option::name('update_core'), false);
 		update_option(Option::name('auto_update_core'), false);
 
-		$this->assertFalse(Option::get('update_core'));
-		$this->assertFalse(Option::get('auto_update_core'));
+		$this->assertFalse(Option::isOn('update_core'));
+		$this->assertFalse(Option::isOn('auto_update_core'));
 	}
 
 	/** @testdox should not affect "update_core" when "auto_update_core" is `false` */
@@ -131,8 +131,8 @@ class ManageCoreTest extends WPTestCase
 	{
 		update_option(Option::name('auto_update_core'), false);
 
-		$this->assertFalse(Option::get('auto_update_core'));
-		$this->assertTrue(Option::get('update_core'));
+		$this->assertFalse(Option::isOn('auto_update_core'));
+		$this->assertTrue(Option::isOn('update_core'));
 	}
 
 	/** @testdox should affect "auto_update_core" when "update_core" is `false` */
@@ -140,8 +140,8 @@ class ManageCoreTest extends WPTestCase
 	{
 		update_option(Option::name('update_core'), false);
 
-		$this->assertFalse(Option::get('update_core'));
-		$this->assertFalse(Option::get('auto_update_core'));
+		$this->assertFalse(Option::isOn('update_core'));
+		$this->assertFalse(Option::isOn('auto_update_core'));
 	}
 
 	/** @testdox should affect all options when "updates" option is `false` */
@@ -149,8 +149,8 @@ class ManageCoreTest extends WPTestCase
 	{
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('update_core'));
-		$this->assertFalse(Option::get('auto_update_core'));
+		$this->assertFalse(Option::isOn('update_core'));
+		$this->assertFalse(Option::isOn('auto_update_core'));
 	}
 
 	/** @testdox should affect "auto_update_core" when "auto_updates" option is `false` */
@@ -158,8 +158,8 @@ class ManageCoreTest extends WPTestCase
 	{
 		update_option(Option::name('auto_updates'), false);
 
-		$this->assertTrue(Option::get('update_core'));
-		$this->assertFalse(Option::get('auto_update_core'));
+		$this->assertTrue(Option::isOn('update_core'));
+		$this->assertFalse(Option::isOn('auto_update_core'));
 	}
 
 	/** @testdox should prune the core update transient information */

--- a/tests/phpunit/app/Features/Updates/ManagePluginsTest.php
+++ b/tests/phpunit/app/Features/Updates/ManagePluginsTest.php
@@ -96,8 +96,8 @@ class ManagePluginsTest extends WPTestCase
 	/** @testdox should return default values */
 	public function testOptionsDefault(): void
 	{
-		$this->assertTrue(Option::get('update_plugins'));
-		$this->assertTrue(Option::get('auto_update_plugins'));
+		$this->assertTrue(Option::isOn('update_plugins'));
+		$this->assertTrue(Option::isOn('auto_update_plugins'));
 	}
 
 	/** @testdox should return updated values */
@@ -106,8 +106,8 @@ class ManagePluginsTest extends WPTestCase
 		update_option(Option::name('update_plugins'), false);
 		update_option(Option::name('auto_update_plugins'), false);
 
-		$this->assertFalse(Option::get('update_plugins'));
-		$this->assertFalse(Option::get('auto_update_plugins'));
+		$this->assertFalse(Option::isOn('update_plugins'));
+		$this->assertFalse(Option::isOn('auto_update_plugins'));
 	}
 
 	/** @testdox should not affect "update_plugins" when "auto_update_plugins" is `false` */
@@ -115,8 +115,8 @@ class ManagePluginsTest extends WPTestCase
 	{
 		update_option(Option::name('auto_update_plugins'), false);
 
-		$this->assertFalse(Option::get('auto_update_plugins'));
-		$this->assertTrue(Option::get('update_plugins'));
+		$this->assertFalse(Option::isOn('auto_update_plugins'));
+		$this->assertTrue(Option::isOn('update_plugins'));
 	}
 
 	/** @testdox should affect "auto_update_plugins" when "update_plugins" is `false` */
@@ -124,8 +124,8 @@ class ManagePluginsTest extends WPTestCase
 	{
 		update_option(Option::name('update_plugins'), false);
 
-		$this->assertFalse(Option::get('update_plugins'));
-		$this->assertFalse(Option::get('auto_update_plugins'));
+		$this->assertFalse(Option::isOn('update_plugins'));
+		$this->assertFalse(Option::isOn('auto_update_plugins'));
 	}
 
 	/** @testdox should affect all options when "updates" option is `false` */
@@ -133,8 +133,8 @@ class ManagePluginsTest extends WPTestCase
 	{
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('update_plugins'));
-		$this->assertFalse(Option::get('auto_update_plugins'));
+		$this->assertFalse(Option::isOn('update_plugins'));
+		$this->assertFalse(Option::isOn('auto_update_plugins'));
 	}
 
 	/** @testdox should affect "auto_update_plugins" when "auto_updates" option is `false` */
@@ -142,8 +142,8 @@ class ManagePluginsTest extends WPTestCase
 	{
 		update_option(Option::name('auto_updates'), false);
 
-		$this->assertTrue(Option::get('update_plugins'));
-		$this->assertFalse(Option::get('auto_update_plugins'));
+		$this->assertTrue(Option::isOn('update_plugins'));
+		$this->assertFalse(Option::isOn('auto_update_plugins'));
 	}
 
 	/** @testdox should prune the plugins update transient information */

--- a/tests/phpunit/app/Features/Updates/ManageThemesTest.php
+++ b/tests/phpunit/app/Features/Updates/ManageThemesTest.php
@@ -96,8 +96,8 @@ class ManageThemesTest extends WPTestCase
 	/** @testdox should return default values */
 	public function testOptionsDefault(): void
 	{
-		$this->assertTrue(Option::get('update_themes'));
-		$this->assertTrue(Option::get('auto_update_themes'));
+		$this->assertTrue(Option::isOn('update_themes'));
+		$this->assertTrue(Option::isOn('auto_update_themes'));
 	}
 
 	/** @testdox should return updated values */
@@ -106,8 +106,8 @@ class ManageThemesTest extends WPTestCase
 		update_option(Option::name('update_themes'), false);
 		update_option(Option::name('auto_update_themes'), false);
 
-		$this->assertFalse(Option::get('update_themes'));
-		$this->assertFalse(Option::get('auto_update_themes'));
+		$this->assertFalse(Option::isOn('update_themes'));
+		$this->assertFalse(Option::isOn('auto_update_themes'));
 	}
 
 	/** @testdox should not affect "update_themes" when "auto_update_themes" is `false` */
@@ -115,8 +115,8 @@ class ManageThemesTest extends WPTestCase
 	{
 		update_option(Option::name('auto_update_themes'), false);
 
-		$this->assertFalse(Option::get('auto_update_themes'));
-		$this->assertTrue(Option::get('update_themes'));
+		$this->assertFalse(Option::isOn('auto_update_themes'));
+		$this->assertTrue(Option::isOn('update_themes'));
 	}
 
 	/** @testdox should affect "auto_update_themes" when "update_themes" is `false` */
@@ -124,8 +124,8 @@ class ManageThemesTest extends WPTestCase
 	{
 		update_option(Option::name('update_themes'), false);
 
-		$this->assertFalse(Option::get('update_themes'));
-		$this->assertFalse(Option::get('auto_update_themes'));
+		$this->assertFalse(Option::isOn('update_themes'));
+		$this->assertFalse(Option::isOn('auto_update_themes'));
 	}
 
 	/** @testdox should affect all options when "updates" option is `false` */
@@ -133,8 +133,8 @@ class ManageThemesTest extends WPTestCase
 	{
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('update_themes'));
-		$this->assertFalse(Option::get('auto_update_themes'));
+		$this->assertFalse(Option::isOn('update_themes'));
+		$this->assertFalse(Option::isOn('auto_update_themes'));
 	}
 
 	/** @testdox should affect "auto_update_themes" when "auto_updates" option is `false` */
@@ -142,8 +142,8 @@ class ManageThemesTest extends WPTestCase
 	{
 		update_option(Option::name('auto_updates'), false);
 
-		$this->assertTrue(Option::get('update_themes'));
-		$this->assertFalse(Option::get('auto_update_themes'));
+		$this->assertTrue(Option::isOn('update_themes'));
+		$this->assertFalse(Option::isOn('auto_update_themes'));
 	}
 
 	/** @testdox should prune the themes update transient information */

--- a/tests/phpunit/app/Features/UpdatesTest.php
+++ b/tests/phpunit/app/Features/UpdatesTest.php
@@ -61,8 +61,8 @@ class UpdatesTest extends WPTestCase
 	/** @testdox should return default values */
 	public function testOptionsDefault(): void
 	{
-		$this->assertTrue(Option::get('updates'));
-		$this->assertTrue(Option::get('auto_updates'));
+		$this->assertTrue(Option::isOn('updates'));
+		$this->assertTrue(Option::isOn('auto_updates'));
 	}
 
 	/** @testdox should return updated values */
@@ -71,8 +71,8 @@ class UpdatesTest extends WPTestCase
 		update_option(Option::name('updates'), false);
 		update_option(Option::name('auto_updates'), false);
 
-		$this->assertFalse(Option::get('updates'));
-		$this->assertFalse(Option::get('auto_updates'));
+		$this->assertFalse(Option::isOn('updates'));
+		$this->assertFalse(Option::isOn('auto_updates'));
 	}
 
 	/** @testdox should return `false` for "auto_updates" when "updates" option is `false` */
@@ -80,7 +80,7 @@ class UpdatesTest extends WPTestCase
 	{
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('updates'));
-		$this->assertFalse(Option::get('auto_updates'));
+		$this->assertFalse(Option::isOn('updates'));
+		$this->assertFalse(Option::isOn('auto_updates'));
 	}
 }

--- a/tests/phpunit/app/Helpers/AutoUpdateTest.php
+++ b/tests/phpunit/app/Helpers/AutoUpdateTest.php
@@ -17,7 +17,7 @@ class AutoUpdateTest extends WPTestCase
 	/** @testdox should return inherited value */
 	public function testGlobal(): void
 	{
-		$this->assertTrue(Option::get('updates'));
+		$this->assertTrue(Option::isOn('updates'));
 
 		$this->assertTrue(AutoUpdate::global()->isEnabled(true));
 		$this->assertFalse(AutoUpdate::global()->isEnabled(false));
@@ -26,7 +26,7 @@ class AutoUpdateTest extends WPTestCase
 		update_option(Option::name('updates'), false);
 
 		// Should return false when global updates are disabled.
-		$this->assertFalse(Option::get('updates'));
+		$this->assertFalse(Option::isOn('updates'));
 		$this->assertFalse(AutoUpdate::global()->isEnabled(true));
 	}
 
@@ -43,7 +43,7 @@ class AutoUpdateTest extends WPTestCase
 		// Disable global updates.
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('updates'));
+		$this->assertFalse(Option::isOn('updates'));
 		$this->assertFalse(AutoUpdate::core()->isEnabled(true));
 	}
 
@@ -53,8 +53,8 @@ class AutoUpdateTest extends WPTestCase
 		// Disable global auto-update.
 		update_option(Option::name('auto_updates'), false);
 
-		$this->assertTrue(Option::get('updates'));
-		$this->assertFalse(Option::get('auto_updates'));
+		$this->assertTrue(Option::isOn('updates'));
+		$this->assertFalse(Option::isOn('auto_updates'));
 		$this->assertFalse(AutoUpdate::core()->isEnabled(true));
 	}
 
@@ -71,7 +71,7 @@ class AutoUpdateTest extends WPTestCase
 		// Disable global updates.
 		update_option(Option::name('updates'), false);
 
-		$this->assertFalse(Option::get('updates'));
+		$this->assertFalse(Option::isOn('updates'));
 		$this->assertFalse(AutoUpdate::plugins()->isEnabled(true));
 	}
 

--- a/tests/phpunit/app/Helpers/OptionTest.php
+++ b/tests/phpunit/app/Helpers/OptionTest.php
@@ -18,7 +18,7 @@ class OptionTest extends WPTestCase
 	/** @testdox should return `false` when the option does not exist */
 	public function testGet(): void
 	{
-		$this->assertFalse(Option::get('foo'));
+		$this->assertFalse(Option::isOn('foo'));
 	}
 
 	/** @testdox should return the value that's been updated */

--- a/tests/phpunit/app/Modules/GeneralTest.php
+++ b/tests/phpunit/app/Modules/GeneralTest.php
@@ -36,8 +36,8 @@ class GeneralTest extends WPTestCase
 	/** @testdox should default values */
 	public function testDefaultOptions(): void
 	{
-		$this->assertTrue(Option::get('block_based_widgets'));
-		$this->assertTrue(Option::get('revisions'));
+		$this->assertTrue(Option::isOn('block_based_widgets'));
+		$this->assertTrue(Option::isOn('revisions'));
 	}
 
 	/** @testdox should return updated values */
@@ -46,8 +46,8 @@ class GeneralTest extends WPTestCase
 		update_option(Option::name('block_based_widgets'), false);
 		update_option(Option::name('revisions'), false);
 
-		$this->assertFalse(Option::get('block_based_widgets'));
-		$this->assertFalse(Option::get('revisions'));
+		$this->assertFalse(Option::isOn('block_based_widgets'));
+		$this->assertFalse(Option::isOn('revisions'));
 	}
 
 	/** @testdox should return inherited value */


### PR DESCRIPTION
@tfirdaus Would you merge a PR that replaces every ["enabled checking"](https://github.com/search?q=repo%3Asyntatis%2Fwp-feature-flipper%20option%3A%3Aget&type=code) with `Option::isOn`?