### PR TITLE
Add `inline` class

### DIFF
--- a/src/setting-page/form/FormNotice.jsx
+++ b/src/setting-page/form/FormNotice.jsx
@@ -35,7 +35,7 @@ export const FormNotice = () => {
 	return (
 		message && (
 			<Notice
-				className={ styles.root }
+				className={ `${ styles.root } inline` }
 				isDismissable
 				level={ getNoticeLevel( status ) }
 				onDismiss={ () => setStatus( null ) }

--- a/src/setting-page/tabs/AdvancedTab.jsx
+++ b/src/setting-page/tabs/AdvancedTab.jsx
@@ -8,7 +8,7 @@ import styles from './AdvancedTab.module.scss';
 export const AdvancedTab = () => {
 	return (
 		<>
-			<Notice className={ styles.notice } level="warning">
+			<Notice className={ `${ styles.notice } inline` } level="warning">
 				<strong>
 					{ __( 'Caution:', 'syntatis-feature-flipper' ) }
 				</strong>


### PR DESCRIPTION
The Pull Request add the `inline` class to the `Notice` component to prevent WordPress move the notice from the initial position to under the page setting heading.

**Reference:** https://github.com/WordPress/wordpress-develop/blob/f33ee44c8c51b8f7a8d9cd8c647f9a85d2bebcd4/src/js/_enqueues/admin/common.js#L1084