### PR TITLE
Fix blueprint

### DIFF
--- a/.wporg/blueprints/blueprint.json
+++ b/.wporg/blueprints/blueprint.json
@@ -13,7 +13,7 @@
             "step": "installPlugin",
             "pluginZipFile": {
                 "resource": "wordpress.org\/plugins",
-                "slug": "my-imaginary-plugin-dependency"
+                "slug": "syntatis-feature-flipper"
             },
             "options": {
                 "activate": true

--- a/.wporg/blueprints/blueprint.json
+++ b/.wporg/blueprints/blueprint.json
@@ -8,6 +8,16 @@
     "steps": [
         {
             "step": "login"
+        },
+        {
+            "step": "installPlugin",
+            "pluginZipFile": {
+                "resource": "wordpress.org\/plugins",
+                "slug": "my-imaginary-plugin-dependency"
+            },
+            "options": {
+                "activate": true
+            }
         }
     ]
 }


### PR DESCRIPTION
The installation step was missing.

https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/
