### PR TITLE
WooCommerce-ize URL detection

### DIFF
--- a/app/Helpers/URL.php
+++ b/app/Helpers/URL.php
@@ -68,7 +68,7 @@ final class URL
 		 * account details, view past orders, etc. When they are not logged in
 		 * this page will show the login form.
 		 */
-		if (did_action('woocommerce_loaded') && ! is_user_logged_in()) {
+		if (did_action('woocommerce_loaded') !== 0 && ! is_user_logged_in()) {
 			return is_account_page();
 		}
 

--- a/app/Helpers/URL.php
+++ b/app/Helpers/URL.php
@@ -6,8 +6,8 @@ namespace Syntatis\FeatureFlipper\Helpers;
 
 use Syntatis\FeatureFlipper\Concerns\DontInstantiate;
 
-use function class_exists;
-use function is_numeric;
+use function did_action;
+use function is_account_page;
 use function is_string;
 use function parse_url;
 use function rtrim;
@@ -65,15 +65,11 @@ final class URL
 
 		/**
 		 * WooCommerce MyAccount is a dedicated page where users can manage their
-		 * account details, view past orders, etc. When they are not loggee in
+		 * account details, view past orders, etc. When they are not logged in
 		 * this page will show the login form.
 		 */
-		if (class_exists('woocommerce') && ! is_user_logged_in()) {
-			$myAccountPageId = get_option('woocommerce_myaccount_page_id');
-
-			if (is_numeric($myAccountPageId)) {
-				return self::parsePath((string) get_permalink(absint($myAccountPageId))) === $urlPath;
-			}
+		if (did_action('woocommerce_loaded') && ! is_user_logged_in()) {
+			return is_account_page();
 		}
 
 		return false;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -76,4 +76,5 @@
 
 	<!-- Exclude directories -->
 	<exclude-pattern>/tests/phpunit/bootstrap.php</exclude-pattern>
+	<exclude-pattern>/tests/phpstan/woocommerce-stubs.php</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,7 @@ parameters:
   level: 10
   bootstrapFiles:
     - dist/autoload/vendor/autoload.php
+    - tests/phpstan/woocommerce-stubs.php
   paths:
     - app
 

--- a/tests/phpstan/woocommerce-stubs.php
+++ b/tests/phpstan/woocommerce-stubs.php
@@ -1,0 +1,4 @@
+<?php
+
+/** @return bool */
+function is_account_page {}

--- a/tests/phpstan/woocommerce-stubs.php
+++ b/tests/phpstan/woocommerce-stubs.php
@@ -1,4 +1,4 @@
 <?php
 
 /** @return bool */
-function is_account_page {}
+function is_account_page() {}


### PR DESCRIPTION
- detect WooCommerce https://developer.woocommerce.com/docs/how-to-check-if-woocommerce-is-active/
- use a [conditional tag](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-conditional-functions.html#source-view.170) https://developer.woocommerce.com/docs/conditional-tags-in-woocommerce/

🎁 a typo fix @tfirdaus 