### PR TITLE
Add a new setting to disable email

### DIFF
--- a/app/InlineData.php
+++ b/app/InlineData.php
@@ -53,7 +53,7 @@ final class InlineData implements ArrayAccess, JsonSerializable
 	/**
 	 * @param mixed $offset
 	 *
-	 * @return mixed $offset
+	 * @return mixed
 	 */
 	public function offsetGet($offset)
 	{

--- a/app/Modules/Mail.php
+++ b/app/Modules/Mail.php
@@ -44,5 +44,13 @@ final class Mail implements Hookable
 			},
 			PHP_INT_MAX,
 		);
+
+		$hook->addFilter(
+			'pre_wp_mail',
+			static function ($value) {
+				return (bool) Option::get('mail_sending') ? $value : false;
+			},
+			PHP_INT_MAX,
+		);
 	}
 }

--- a/inc/settings/all.php
+++ b/inc/settings/all.php
@@ -188,6 +188,8 @@ return [
 	 *
 	 * @see \Syntatis\FeatureFlipper\Modules\Email
 	 */
+	(new Setting('mail_sending', 'boolean'))
+		->withDefault(true),
 	(new Setting('mail_from_address'))
 		->withDefault(null),
 	(new Setting('mail_from_name'))

--- a/src/setting-page/tabs/MailTab.jsx
+++ b/src/setting-page/tabs/MailTab.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Fieldset, Form, useSettingsContext } from '../form';
-import { TextFieldset } from '../fieldset';
+import { SwitchFieldset, TextFieldset } from '../fieldset';
 
 export const MailTab = () => {
 	const { inlineData } = useSettingsContext();
@@ -8,6 +8,21 @@ export const MailTab = () => {
 
 	return (
 		<Form>
+			<Fieldset>
+				<SwitchFieldset
+					name="mail_sending"
+					id="mail-sending"
+					title={ __( 'Sending', 'syntatis-feature-flipper' ) }
+					label={ __(
+						'Enable sending emails',
+						'syntatis-feature-flipper'
+					) }
+					description={ __(
+						'If switched off, WordPress will not send any emails.',
+						'syntatis-feature-flipper'
+					) }
+				/>
+			</Fieldset>
 			<Fieldset
 				title={ __( 'Attributes', 'syntatis-feature-flipper' ) }
 				description={ __(

--- a/tests/phpunit/app/Modules/MailTest.php
+++ b/tests/phpunit/app/Modules/MailTest.php
@@ -55,4 +55,19 @@ class MailTest extends WPTestCase
 		$this->assertSame('Acme', Option::get('mail_from_name'));
 		$this->assertSame('Acme', apply_filters('wp_mail_from_name', 'WordPress'));
 	}
+
+	public function testMailSendingDefault(): void
+	{
+		$this->assertTrue(Option::get('mail_sending'));
+	}
+
+	public function testMailSendingFilter(): void
+	{
+		$this->assertNull(apply_filters('pre_wp_mail', null));
+
+		$this->assertTrue(Option::update('mail_sending', false));
+		$this->assertFalse(Option::get('mail_sending'));
+
+		$this->assertFalse(apply_filters('pre_wp_mail', null));
+	}
 }


### PR DESCRIPTION
There are several ways to disable email sending in WordPress, but for now, we're keeping it simple **for now** by using the `pre_wp_mail` filter. It's not foolproof, but it covers most use cases.